### PR TITLE
moving call to 'authorize' prior to 'beforeSave'

### DIFF
--- a/src/resteasy.js
+++ b/src/resteasy.js
@@ -175,8 +175,8 @@ function *create(next) {
     hash['created_at'] = this.resteasy.knex.fn.now();
   }
 
-  yield hook(this, 'beforeSave');
   yield hook(this, 'authorize', 'create', hash);
+  yield hook(this, 'beforeSave');
 
   queries.create(this.resteasy.query, hash);
 
@@ -198,8 +198,8 @@ function *update(next) {
     hash['updated_at'] = this.resteasy.knex.fn.now();
   }
 
-  yield hook(this, 'beforeSave');
   yield hook(this, 'authorize', 'update', this.params.id);
+  yield hook(this, 'beforeSave');
 
   queries.update(this.resteasy.query, this.params.id, this.resteasy.object);
 


### PR DESCRIPTION
beforeSave may include expensive activities (calling other APIs, manipulating JSON, etc). It would be good to check if it's an authorized activity before incurring the expense of invocation.